### PR TITLE
fix: Navbar active page color

### DIFF
--- a/code/about.html
+++ b/code/about.html
@@ -38,7 +38,7 @@
             </button>
             <div class="collapse navbar-collapse" id="navbarCollapse">
                 <div class="navbar-nav ml-auto py-0 pr-3 border-right">
-                    <a href="index.html" class="nav-item nav-link active">Home</a>
+                    <a href="index.html" class="nav-item nav-link">Home</a>
                     <a href="about.html" class="nav-item nav-link">About</a>
                     <a href="service.html" class="nav-item nav-link">What's New ?</a>
                     <a href="project.html" class="nav-item nav-link">Newsletter</a>

--- a/code/contact.html
+++ b/code/contact.html
@@ -38,7 +38,7 @@
         </button>
         <div class="collapse navbar-collapse" id="navbarCollapse">
             <div class="navbar-nav ml-auto py-0 pr-3 border-right">
-                <a href="index.html" class="nav-item nav-link active">Home</a>
+                <a href="index.html" class="nav-item nav-link">Home</a>
                 <a href="about.html" class="nav-item nav-link">About</a>
                 <a href="service.html" class="nav-item nav-link">What's New ?</a>
                 <a href="project.html" class="nav-item nav-link">Newsletter</a>

--- a/code/index.html
+++ b/code/index.html
@@ -38,7 +38,7 @@
             </button>
             <div class="collapse navbar-collapse" id="navbarCollapse">
                 <div class="navbar-nav ml-auto py-0 pr-3 border-right">
-                    <a href="index.html" class="nav-item nav-link active">Home</a>
+                    <a href="index.html" class="nav-item nav-link">Home</a>
                     <a href="about.html" class="nav-item nav-link">About</a>
                     <a href="service.html" class="nav-item nav-link">What's New ?</a>
                     <a href="project.html" class="nav-item nav-link">Newsletter</a>

--- a/code/js/main.js
+++ b/code/js/main.js
@@ -98,6 +98,14 @@
             }
         }
     });
+
+    // Current URL updator
+    let current_url = document.location;
+    document.querySelectorAll(".nav-item").forEach(function(e){
+       if(e.href == current_url){
+          e.classList += " active";
+       }
+    });
     
 })(jQuery);
 

--- a/code/project.html
+++ b/code/project.html
@@ -38,7 +38,7 @@
             </button>
             <div class="collapse navbar-collapse" id="navbarCollapse">
                 <div class="navbar-nav ml-auto py-0 pr-3 border-right">
-                    <a href="index.html" class="nav-item nav-link active">Home</a>
+                    <a href="index.html" class="nav-item nav-link">Home</a>
                     <a href="about.html" class="nav-item nav-link">About</a>
                     <a href="service.html" class="nav-item nav-link">What's New ?</a>
                     <a href="project.html" class="nav-item nav-link">Newsletter</a>

--- a/code/scss/style.scss
+++ b/code/scss/style.scss
@@ -78,7 +78,7 @@ h6,
 }
 
 .navbar-light .navbar-nav .nav-link:hover,
-.navbar-light .navbar-nav .nav-link.active {
+.navbar-light .navbar-nav .nav-link .active {
     color: $primary;
 }
 

--- a/code/service.html
+++ b/code/service.html
@@ -38,7 +38,7 @@
             </button>
             <div class="collapse navbar-collapse" id="navbarCollapse">
                 <div class="navbar-nav ml-auto py-0 pr-3 border-right">
-                    <a href="index.html" class="nav-item nav-link active">Home</a>
+                    <a href="index.html" class="nav-item nav-link">Home</a>
                     <a href="about.html" class="nav-item nav-link">About</a>
                     <a href="service.html" class="nav-item nav-link">What's New ?</a>
                     <a href="project.html" class="nav-item nav-link">Newsletter</a>


### PR DESCRIPTION
#18 

Noticed that when navigating thorugh the different pages in navbar Home was always selected while current page did not get a color update at navbar, although the page did load.

Bug was due to class "active" being forcedly set on homepage at the html of every page.

Besides, I added a script at main.js that once any page has loaded, gets the current url and updates the corresponding .nav-item's class adding .active so that its color can get updated. 

I'd appreciate if it counted for hacktoberfest!

After fix:
![Screenshot from 2022-10-04 12-18-36](https://user-images.githubuserc
![Screenshot from 2022-10-04 12-18-38](https://user-images.githubusercontent.com/92840840/193795493-e3ec9f86-7dc5-4bda-92c0-e4faa7f936c5.png)
ontent.com/92840840/1
![Screenshot from 2022-10-04 12-20-11](https://user-images.githubusercontent.com/92840840/193795500-165c2849-69fe-4f58-b2d3-5d3be4ce10fb.png)
93795482-deb1946c-8eeb-4cb2-a697-4deafb296726.png)
